### PR TITLE
Add \lstset{texcl=true} to latex publish template

### DIFF
--- a/scripts/miscellaneous/private/__publish_latex_output__.m
+++ b/scripts/miscellaneous/private/__publish_latex_output__.m
@@ -146,7 +146,8 @@ function outstr = do_header (title_str, intro_str, toc_cstr)
 'frame=single,',
 'tabsize=2,',
 'showstringspaces=false,',
-'breaklines=true}');
+'breaklines=true,',
+'texcl=true}');
 
   latex_head = sprintf ("%s\n",
 "",


### PR DESCRIPTION
This makes comment lines to be treated as LaTeX in code blocks outputted in `publish` command. Fixes a bug where having UTF-8 characters in comments would cause `pdflatex` to fail when rendering a document with error `! Package inputenc Error: Invalid UTF-8 byte sequence.`.