### PR TITLE
Fix lower bound for GLP_DB

### DIFF
--- a/libinterp/dldfcn/__glpk__.cc
+++ b/libinterp/dldfcn/__glpk__.cc
@@ -167,7 +167,7 @@ glpk (int sense, int n, int m, double *c, int nz, int *rn, int *cn,
           break;
         }
 
-      glp_set_row_bnds (lp, i+1, typx, b[i], b[i]);
+      glp_set_row_bnds (lp, i+1, typx, typx == GLP_DB ? -b[i] : b[i], b[i]);
 
     }
 


### PR DESCRIPTION
Found a small bug in the GLPK interface:
For doubly bound constraints (ctype "D"), the lower bound for `glp_set_row_bnds()` was not correct.