### PR TITLE
Add other libs

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -981,7 +981,7 @@ AC_DEFUN([OCTAVE_CHECK_LIB], [
       if test -z "$m4_toupper(patsubst([$1], [-], [_]))_LDFLAGS"; then
         m4_toupper(patsubst([$1], [-], [_]))_LDFLAGS="$($PKG_CONFIG --libs-only-L m4_default([$9], [$1]) | $SED -e 's/^ *$//')"
       fi
-      m4_toupper(patsubst([$1], [-], [_]))_LIBS="$($PKG_CONFIG --libs-only-l m4_default([$9], [$1]) | $SED -e 's/^ *$//')"
+      m4_toupper(patsubst([$1], [-], [_]))_LIBS="$($PKG_CONFIG --libs-only-l --libs-only-other m4_default([$9], [$1]) | $SED -e 's/^ *$//')"
     ])
   fi
 
@@ -2280,7 +2280,7 @@ AC_DEFUN([OCTAVE_CHECK_QT_VERSION], [AC_MSG_CHECKING([Qt version $1])
       ## Retrieve Qt compilation and linker flags
       QT_CPPFLAGS="$($PKG_CONFIG --cflags-only-I $QT_MODULES | $SED -e 's/^ *$//')"
       QT_LDFLAGS="$($PKG_CONFIG --libs-only-L $QT_MODULES | $SED -e 's/^ *$//')"
-      QT_LIBS="$($PKG_CONFIG --libs-only-l $QT_MODULES | $SED -e 's/^ *$//')"
+      QT_LIBS="$($PKG_CONFIG --libs-only-l --libs-only-other $QT_MODULES | $SED -e 's/^ *$//')"
 
       case $host_os in
         *darwin*)


### PR DESCRIPTION
Add other libs.
In vcpkg we compile octave dynamic with static libs. 
Example how it inside Qt5Core.pc file:

```
Libs: "-L${libdir}" -lQt5Core "-L${prefix}/lib" "-L${prefix}/lib/manual-link" -lpthread -lm ${prefix}/lib/libz.a -ldouble-conversion "-L${prefix}/lib/pkgconfig/../../lib" -lpcre2-16 ${prefix}/lib/libpng16.a ${prefix}/lib/libz.a
```

The direct linkage of zlib library is consider other lib, needed for compilation when compile the gui feature. 