### PR TITLE
mean: fix typo in weighted mean formula documentation

### DIFF
--- a/scripts/statistics/mean.m
+++ b/scripts/statistics/mean.m
@@ -57,7 +57,7 @@
 ## @ifnottex
 ##
 ## @example
-## weighted_mean (@var{x}) = SUM_i (@var{w}(i) * @var{x}(i)) / SUM_i (@var{w}(i)
+## weighted_mean (@var{x}) = SUM_i (@var{w}(i) * @var{x}(i)) / SUM_i (@var{w}(i))
 ## @end example
 ##
 ## @noindent


### PR DESCRIPTION
This patch fixes a small typo in the weighted mean formula in the help text for `mean`.
No functional changes.
