### PR TITLE
median: use nth_element for linear-time selection on dense inputs

### DIFF
--- a/scripts/statistics/median.m
+++ b/scripts/statistics/median.m
@@ -555,35 +555,13 @@ endfunction
 
 ## Compute mean of two middle values, handling Inf and integer overflow.
 function m = mid_two_vals (m1, m2, is_int)
-  infmask = isinf (m1) | isinf (m2);
-
   if (is_int)
     samesign = sign (m1) == sign (m2);
     m = samesign .* (m1 + (m2 - m1) / 2) + ! samesign .* ((m1 + m2) / 2);
   else
     m = (m1 + m2) / 2;
   endif
-
-  m(infmask) = m1(infmask) + m2(infmask);
 endfunction
-
-
-## Tests for per-element Inf handling in even-length median
-%!test
-%! x = [-Inf, 2; 1, 3];
-%! assert (median (x, 1), [-Inf, 2.5]);
-
-%!test
-%! x = [-Inf, Inf; Inf, -Inf];
-%! assert (median (x, 1), [NaN, NaN]);
-
-%!test
-%! x = [1, Inf, 3; 5, 7, 9];
-%! assert (median (x, 1), [3, Inf, 6]);
-
-%!test
-%! x = int64 ([10, 20; 30, 40]);
-%! assert (median (x, 1), int64 ([20, 30]));
 
 
 %!assert (median (1), 1)

--- a/scripts/statistics/median.m
+++ b/scripts/statistics/median.m
@@ -297,7 +297,7 @@ function m = median (x, varargin)
     return;
   endif
 
-  ## Permute dim to simplify all operations along dim1.  At func. end ipermute.
+  ## Permute dim to simplify all operations along dim1
   if (numel (dim) > 1 || (dim != 1 && ! isvector (x)))
     perm = 1 : ndx;
 
@@ -338,9 +338,7 @@ function m = median (x, varargin)
   ## Dense inputs use nth_element for O(n) selection instead of O(n log n) sort.
 
   if (xsparse)
-    ## Sparse code path: use sort (preserves historical behavior and sparsity)
-    ## By “historical behavior” I mean: the existing median implementation for sparse inputs is left unchanged
-    ## preserves sparsity of the output, preserves the exact NaN and zero handlinggit status
+    # use sort for sparse matrices to retain sparsity of output
     x = sort (x, dim);
 
     if (omitnan)
@@ -358,11 +356,10 @@ function m = median (x, varargin)
       else
         n = sum (! isnan (x), 1)(:);
         k = floor ((n + 1) / 2);
-        m_idx_odd = mod (n, 2) & n;
-        m_idx_even = (! m_idx_odd) & n;
+        odd_cols = mod (n, 2) & n;
+        even_cols = ! odd_cols & n;
 
-        m = NaN ([1, szx(2 : end)]);
-        m = sparse (m);
+        m = sparse (NaN ([1, szx(2 : end)]));
 
         if (ndims (x) > 2)
           szx_flat = [szx(1), prod(szx(2 : end))];
@@ -370,15 +367,15 @@ function m = median (x, varargin)
           szx_flat = szx;
         endif
 
-        if (any (m_idx_odd))
-          x_idx_odd = sub2ind (szx_flat, k(m_idx_odd), find (m_idx_odd));
-          m(m_idx_odd) = x(x_idx_odd);
+        if (any (odd_cols))
+          idx = sub2ind (szx_flat, k(odd_cols), find (odd_cols));
+          m(odd_cols) = x(idx);
         endif
-        if (any (m_idx_even))
-          k_even = k(m_idx_even);
-          x_idx_even = sub2ind (szx_flat, [k_even, k_even + 1], ...
-                                  (find (m_idx_even))(:, [1, 1]));
-          m(m_idx_even) = sum (x(x_idx_even), 2) / 2;
+        if (any (even_cols))
+          k_even = k(even_cols);
+          idx = sub2ind (szx_flat, [k_even, k_even + 1], ...
+                         find (even_cols)(:, [1, 1]));
+          m(even_cols) = sum (x(idx), 2) / 2;
         endif
       endif
 
@@ -407,8 +404,7 @@ function m = median (x, varargin)
           n = szx(1);
           k = floor ((n + 1) / 2);
 
-          m = NaN ([1, szx(2 : end)]);
-          m = sparse (m);
+          m = sparse (NaN ([1, szx(2 : end)]));
 
           if (! mod (n, 2))
             m(nanfree) = (x(k, nanfree) + x(k + 1, nanfree)) / 2;
@@ -420,49 +416,28 @@ function m = median (x, varargin)
     endif
 
   else
-    ## Dense code path: use nth_element for O(n) selection
-
+    ## dense: use nth_element for O(n) selection
     if (omitnan)
-      ## Ignore any NaN's in data.  Each operating vector might have a
-      ## different number of non-NaN data points.
-
+      ## Ignore any NaN's in data. 
+      ## Each operating vector might have a different number of non-NaN data points.
       if (isvector (x))
         ## Checks above ensure either dim1 or dim2 vector
         x = x(! isnan (x));
         n = numel (x);
-
         if (n == 0)
           m = NaN (sz_out, outtype);
         else
           k = floor ((n + 1) / 2);
           if (mod (n, 2))
-            ## odd
             m = nth_element (x, k);
           else
-            ## even
             vals = nth_element (x, [k, k + 1]);
-            m = vals(1);
-            if (any (isinf (vals)))
-              ## If either center value is Inf, replace m by +/-Inf or NaN.
-              m = vals(1) + vals(2);
-            elseif (any (isa (x, "integer")))
-              ## avoid int overflow issues
-              m2 = vals(2);
-              if (sign (m) != sign (m2))
-                m += m2;
-                m /= 2;
-              else
-                m += (m2 - m) / 2;
-              endif
-            else
-              m += (vals(2) - m) / 2;
-            endif
+            m = mid_two_vals (vals(1), vals(2), isa (x, "integer"));
           endif
         endif
 
       else
-        ## Each column may have a different n and k.  Flatten higher dimensions
-        ## so nth_element works column-wise.
+        ## Columns may have different non-NaN counts; process individually.
         n = szx(1);
         rest_sz = szx(2 : end);
         ncols = prod (rest_sz);
@@ -493,20 +468,7 @@ function m = median (x, varargin)
             m(j) = nth_element (col, k);
           else
             vals = nth_element (col, [k, k + 1]);
-            m(j) = vals(1);
-            if (any (isinf (vals)))
-              m(j) = vals(1) + vals(2);
-            elseif (any (isa (x, "integer")))
-              m2 = vals(2);
-              if (sign (m(j)) != sign (m2))
-                m(j) += m2;
-                m(j) /= 2;
-              else
-                m(j) += (m2 - m(j)) / 2;
-              endif
-            else
-              m(j) += (vals(2) - m(j)) / 2;
-            endif
+            m(j) = mid_two_vals (vals(1), vals(2), isa (x, "integer"));
           endif
         endfor
 
@@ -516,8 +478,7 @@ function m = median (x, varargin)
       endif
 
     else
-      ## No "omitnan".  All 'vectors' uniform length.
-      ## All types without a NaN value will use this path.
+      ## No "omitnan". All types without a NaN value will use this path.
       if (all (! nanfree))
         m = NaN (sz_out);
 
@@ -535,20 +496,7 @@ function m = median (x, varargin)
             else
               ## Even
               vals = nth_element (x, [k, k + 1]);
-              m = vals(1);
-              if (any (isinf (vals)))
-                m = vals(1) + vals(2);
-              elseif (any (isa (x, "integer")))
-                m2 = vals(2);
-                if (sign (m) != sign (m2))
-                  m += m2;
-                  m /= 2;
-                else
-                  m += (m2 - m) / 2;
-                endif
-              else
-                m += (vals(2) - m) / 2;
-              endif
+              m = mid_two_vals (vals(1), vals(2), isa (x, "integer"));
             endif
           endif
 
@@ -580,14 +528,7 @@ function m = median (x, varargin)
             ## Even
             if (any (nanfree(:)))
               vals = nth_element (x(:, nanfree), [k, k + 1], 1);
-              if (any (isa (x, "integer")))
-                m1 = vals(1, :);
-                m2 = vals(2, :);
-                samesign = prod (sign ([m1; m2]), 1) == 1;
-                m(nanfree) = samesign .* m1 + (m2 + ! samesign .* m1 - samesign .* m1) / 2;
-              else
-                m(nanfree) = (vals(1, :) + vals(2, :)) / 2;
-              endif
+              m(nanfree) = mid_two_vals (vals(1, :), vals(2, :), isa (x, "integer"));
             endif
           endif
 
@@ -609,6 +550,21 @@ function m = median (x, varargin)
     m = feval (outtype, m);
   endif
 
+endfunction
+
+
+## Compute mean of two middle values, handling Inf and integer overflow.
+function m = mid_two_vals (m1, m2, is_int)
+  if (any (isinf ([m1; m2])(:)))
+    m = m1 + m2;
+  elseif (is_int)
+    ## same signs: m1 + (m2-m1)/2 avoids overflow in the sum.
+    ## opposite sign: (m1+m2)/2 is since magnitudes partially cancel.
+    samesign = sign (m2) == sign (m1);
+    m = samesign .* (m1 + (m2 - m1) / 2) + ! samesign .* ((m1 + m2) / 2);
+  else
+    m = (m1 + m2) / 2;
+  endif
 endfunction
 
 

--- a/scripts/statistics/median.m
+++ b/scripts/statistics/median.m
@@ -557,7 +557,9 @@ endfunction
 function m = mid_two_vals (m1, m2, is_int)
   if (is_int)
     samesign = sign (m1) == sign (m2);
-    m = samesign .* (m1 + (m2 - m1) / 2) + ! samesign .* ((m1 + m2) / 2);
+    m = zeros (size (m1), "like", m1);
+    m(samesign) = m1(samesign) + (m2(samesign) - m1(samesign)) / 2;
+    m(! samesign) = (m1(! samesign) + m2(! samesign)) / 2;
   else
     m = (m1 + m2) / 2;
   endif

--- a/scripts/statistics/median.m
+++ b/scripts/statistics/median.m
@@ -131,6 +131,7 @@ function m = median (x, varargin)
   szx = sz_out = size (x);
   ndx = ndims (x);
   outtype = class (x);
+  xsparse = issparse (x);
 
   if (nvarg > 1 && ! varg_chars(2:end))
     ## Only first varargin can be numeric
@@ -266,7 +267,7 @@ function m = median (x, varargin)
     switch (outtype)
       case {"double", "single"}
         m = NaN (sz_out, outtype);
-        if (issparse (x))
+        if (xsparse)
           m = sparse (m);
         endif
       case ("logical")
@@ -280,7 +281,7 @@ function m = median (x, varargin)
   if (all (isnan (x(:))))
     ## all NaN input, output single or double NaNs in pre-determined size
     m = NaN (sz_out, outtype);
-    if (issparse (x))
+    if (xsparse)
       m = sparse (m);
     endif
     return;
@@ -333,124 +334,265 @@ function m = median (x, varargin)
     omitnan = false;
   endif
 
-  x = sort (x, dim); # Note: pushes any NaN's to end for omitnan compatibility
+  ## Sparse inputs use the original sort-based code path to preserve sparsity.
+  ## Dense inputs use nth_element for O(n) selection instead of O(n log n) sort.
 
-  if (omitnan)
-    ## Ignore any NaN's in data.  Each operating vector might have a
-    ## different number of non-NaN data points.
+  if (xsparse)
+    ## Sparse code path: use sort (preserves historical behavior and sparsity)
+    x = sort (x, dim);
 
-    if (isvector (x))
-      ## Checks above ensure either dim1 or dim2 vector
-      x = x(! isnan (x));
-      n = numel (x);
-      k = floor ((n + 1) / 2);
-      if (mod (n, 2))
-        ## odd
-        m = x(k);
+    if (omitnan)
+      if (isvector (x))
+        x = x(! isnan (x));
+        n = numel (x);
+        k = floor ((n + 1) / 2);
+        if (n == 0)
+          m = sparse (NaN);
+        elseif (mod (n, 2))
+          m = sparse (x(k));
+        else
+          m = sparse ((x(k) + x(k + 1)) / 2);
+        endif
       else
-        ## even
-        m = (x(k) + x(k + 1)) / 2;
+        n = sum (! isnan (x), 1)(:);
+        k = floor ((n + 1) / 2);
+        m_idx_odd = mod (n, 2) & n;
+        m_idx_even = (! m_idx_odd) & n;
+
+        m = NaN ([1, szx(2 : end)]);
+        m = sparse (m);
+
+        if (ndims (x) > 2)
+          szx_flat = [szx(1), prod(szx(2 : end))];
+        else
+          szx_flat = szx;
+        endif
+
+        if (any (m_idx_odd))
+          x_idx_odd = sub2ind (szx_flat, k(m_idx_odd), find (m_idx_odd));
+          m(m_idx_odd) = x(x_idx_odd);
+        endif
+        if (any (m_idx_even))
+          k_even = k(m_idx_even);
+          x_idx_even = sub2ind (szx_flat, [k_even, k_even + 1], ...
+                                  (find (m_idx_even))(:, [1, 1]));
+          m(m_idx_even) = sum (x(x_idx_even), 2) / 2;
+        endif
       endif
 
     else
-      ## Each column may have a different n and k.  Force index column vector
-      ## for consistent orientation for 2-D and N-D inputs, then use sub2ind to
-      ## get correct element(s) for each column.
-
-      n = sum (! isnan (x), 1)(:);
-      k = floor ((n + 1) / 2);
-      m_idx_odd = mod (n, 2) & n;
-      m_idx_even = (! m_idx_odd) & n;
-
-      m = NaN ([1, szx(2 : end)]);
-      if (issparse (x))
+      ## No "omitnan" for sparse
+      if (all (! nanfree))
+        m = NaN (sz_out);
         m = sparse (m);
-      endif
 
-      if (ndims (x) > 2)
-        szx = [szx(1), prod(szx(2 : end))];
-      endif
+      else
+        if (isvector (x))
+          n = numel (x);
+          k = floor ((n + 1) / 2);
 
-      ## Grab kth value, k possibly different for each column
-      if (any (m_idx_odd))
-        x_idx_odd = sub2ind (szx, k(m_idx_odd), find (m_idx_odd));
-        m(m_idx_odd) = x(x_idx_odd);
-      endif
-      if (any (m_idx_even))
-        k_even = k(m_idx_even);
-        x_idx_even = sub2ind (szx, [k_even, k_even + 1], ...
-                                (find (m_idx_even))(:, [1, 1]));
-        m(m_idx_even) = sum (x(x_idx_even), 2) / 2;
+          m = x(k);
+          if (! mod (n, 2))
+            if (any (isinf ([x(k), x(k+1)])))
+              m = x(k) + x(k+1);
+            else
+              m += (x(k + 1) - m) / 2;
+            endif
+          endif
+          m = sparse (m);
+
+        else
+          n = szx(1);
+          k = floor ((n + 1) / 2);
+
+          m = NaN ([1, szx(2 : end)]);
+          m = sparse (m);
+
+          if (! mod (n, 2))
+            m(nanfree) = (x(k, nanfree) + x(k + 1, nanfree)) / 2;
+          else
+            m(nanfree) = x(k, nanfree);
+          endif
+        endif
       endif
     endif
 
   else
-    ## No "omitnan".  All 'vectors' uniform length.
-    ## All types without a NaN value will use this path.
-    if (all (! nanfree))
-      m = NaN (sz_out);
-      if (issparse (x))
-        m = sparse (m);
-      endif
+    ## Dense code path: use nth_element for O(n) selection
 
-    else
+    if (omitnan)
+      ## Ignore any NaN's in data.  Each operating vector might have a
+      ## different number of non-NaN data points.
+
       if (isvector (x))
+        ## Checks above ensure either dim1 or dim2 vector
+        x = x(! isnan (x));
         n = numel (x);
-        k = floor ((n + 1) / 2);
 
-        m = x(k);
-        if (! mod (n, 2))
-          ## Even
-          if (any (isinf ([x(k), x(k+1)])))
-            ## If either center value is Inf, replace m by +/-Inf or NaN.
-            m = x(k) + x(k+1);
-          elseif (any (isa (x, "integer")))
-            ## avoid int overflow issues
-            m2 = x(k + 1);
-            if (sign (m) != sign (m2))
-              m += m2;
-              m /= 2;
-            else
-              m += (m2 - m) / 2;
-            endif
+        if (n == 0)
+          m = NaN (sz_out, outtype);
+        else
+          k = floor ((n + 1) / 2);
+          if (mod (n, 2))
+            ## odd
+            m = nth_element (x, k);
           else
-            m += (x(k + 1) - m) / 2;
+            ## even
+            vals = nth_element (x, [k, k + 1]);
+            m = vals(1);
+            if (any (isinf (vals)))
+              ## If either center value is Inf, replace m by +/-Inf or NaN.
+              m = vals(1) + vals(2);
+            elseif (any (isa (x, "integer")))
+              ## avoid int overflow issues
+              m2 = vals(2);
+              if (sign (m) != sign (m2))
+                m += m2;
+                m /= 2;
+              else
+                m += (m2 - m) / 2;
+              endif
+            else
+              m += (vals(2) - m) / 2;
+            endif
           endif
         endif
 
       else
-        ## Nonvector, all operations were permuted to be along dim 1
+        ## Each column may have a different n and k.  Flatten higher dimensions
+        ## so nth_element works column-wise.
         n = szx(1);
-        k = floor ((n + 1) / 2);
+        rest_sz = szx(2 : end);
+        ncols = prod (rest_sz);
 
-        if (isfloat (x))
-          m = NaN ([1, szx(2 : end)]);
-          if (issparse (x))
-            m = sparse (m);
-          endif
-        else
-          m = zeros ([1, szx(2 : end)], outtype);
+        if (ndims (x) > 2)
+          x = reshape (x, [n, ncols]);
         endif
 
-        if (! mod (n, 2))
-          ## Even
-          if (any (isa (x, "integer")))
-            ## avoid int overflow issues
-
-            ## Use flattened index to simplify N-D operations
-            m(1, :) = x(k, :);
-            m2 = x(k + 1, :);
-
-            samesign = prod (sign ([m(1, :); m2]), 1) == 1;
-            m(1, :) = samesign .* m(1, :) + ...
-                       (m2 + !samesign .* m(1, :) - samesign .* m(1, :)) / 2;
-
-          else
-            m(nanfree) = (x(k, nanfree) + x(k + 1, nanfree)) / 2;
-          endif
+        if (isfloat (x))
+          m = NaN (1, ncols);
         else
-          ## Odd.  Use flattened index to simplify N-D operations
-          m(nanfree) = x(k, nanfree);
+          m = zeros (1, ncols, outtype);
+        endif
+
+        x = reshape (x, [n, ncols]);
+
+        for j = 1:ncols
+          col = x(:, j);
+          col = col(! isnan (col));
+          ncol = numel (col);
+
+          if (ncol == 0)
+            continue;
+          endif
+
+          k = floor ((ncol + 1) / 2);
+          if (mod (ncol, 2))
+            m(j) = nth_element (col, k);
+          else
+            vals = nth_element (col, [k, k + 1]);
+            m(j) = vals(1);
+            if (any (isinf (vals)))
+              m(j) = vals(1) + vals(2);
+            elseif (any (isa (x, "integer")))
+              m2 = vals(2);
+              if (sign (m(j)) != sign (m2))
+                m(j) += m2;
+                m(j) /= 2;
+              else
+                m(j) += (m2 - m(j)) / 2;
+              endif
+            else
+              m(j) += (vals(2) - m(j)) / 2;
+            endif
+          endif
+        endfor
+
+        if (numel (rest_sz) > 1)
+          m = reshape (m, [1, rest_sz]);
+        endif
+      endif
+
+    else
+      ## No "omitnan".  All 'vectors' uniform length.
+      ## All types without a NaN value will use this path.
+      if (all (! nanfree))
+        m = NaN (sz_out);
+
+      else
+        if (isvector (x))
+          n = numel (x);
+          k = floor ((n + 1) / 2);
+
+          if (! nanfree)
+            m = NaN (sz_out);
+          else
+            if (mod (n, 2))
+              ## Odd
+              m = nth_element (x, k);
+            else
+              ## Even
+              vals = nth_element (x, [k, k + 1]);
+              m = vals(1);
+              if (any (isinf (vals)))
+                m = vals(1) + vals(2);
+              elseif (any (isa (x, "integer")))
+                m2 = vals(2);
+                if (sign (m) != sign (m2))
+                  m += m2;
+                  m /= 2;
+                else
+                  m += (m2 - m) / 2;
+                endif
+              else
+                m += (vals(2) - m) / 2;
+              endif
+            endif
+          endif
+
+        else
+          ## Nonvector, all operations were permuted to be along dim 1
+          n = szx(1);
+          k = floor ((n + 1) / 2);
+          rest_sz = szx(2 : end);
+          ncols = prod (rest_sz);
+
+          if (isfloat (x))
+            m = NaN (1, ncols);
+          else
+            m = zeros (1, ncols, outtype);
+          endif
+
+          if (ndims (x) > 2)
+            x = reshape (x, [n, ncols]);
+            nanfree = reshape (nanfree, [1, ncols]);
+          endif
+
+          if (mod (n, 2))
+            ## Odd.  Use flattened index to simplify N-D operations
+            if (any (nanfree(:)))
+              vals = nth_element (x(:, nanfree), k, 1);
+              m(nanfree) = vals;
+            endif
+          else
+            ## Even
+            if (any (nanfree(:)))
+              vals = nth_element (x(:, nanfree), [k, k + 1], 1);
+              if (any (isa (x, "integer")))
+                m1 = vals(1, :);
+                m2 = vals(2, :);
+                samesign = prod (sign ([m1; m2]), 1) == 1;
+                m(nanfree) = samesign .* m1 + ...
+                              (m2 + ! samesign .* m1 - samesign .* m1) / 2;
+              else
+                m(nanfree) = (vals(1, :) + vals(2, :)) / 2;
+              endif
+            endif
+          endif
+
+          if (numel (rest_sz) > 1)
+            m = reshape (m, [1, rest_sz]);
+          endif
         endif
       endif
     endif

--- a/scripts/statistics/median.m
+++ b/scripts/statistics/median.m
@@ -339,6 +339,8 @@ function m = median (x, varargin)
 
   if (xsparse)
     ## Sparse code path: use sort (preserves historical behavior and sparsity)
+    ## By “historical behavior” I mean: the existing median implementation for sparse inputs is left unchanged
+    ## preserves sparsity of the output, preserves the exact NaN and zero handlinggit status
     x = sort (x, dim);
 
     if (omitnan)
@@ -582,8 +584,7 @@ function m = median (x, varargin)
                 m1 = vals(1, :);
                 m2 = vals(2, :);
                 samesign = prod (sign ([m1; m2]), 1) == 1;
-                m(nanfree) = samesign .* m1 + ...
-                              (m2 + ! samesign .* m1 - samesign .* m1) / 2;
+                m(nanfree) = samesign .* m1 + (m2 + ! samesign .* m1 - samesign .* m1) / 2;
               else
                 m(nanfree) = (vals(1, :) + vals(2, :)) / 2;
               endif

--- a/scripts/statistics/median.m
+++ b/scripts/statistics/median.m
@@ -555,17 +555,35 @@ endfunction
 
 ## Compute mean of two middle values, handling Inf and integer overflow.
 function m = mid_two_vals (m1, m2, is_int)
-  if (any (isinf ([m1; m2])(:)))
-    m = m1 + m2;
-  elseif (is_int)
-    ## same signs: m1 + (m2-m1)/2 avoids overflow in the sum.
-    ## opposite sign: (m1+m2)/2 is since magnitudes partially cancel.
-    samesign = sign (m2) == sign (m1);
+  infmask = isinf (m1) | isinf (m2);
+
+  if (is_int)
+    samesign = sign (m1) == sign (m2);
     m = samesign .* (m1 + (m2 - m1) / 2) + ! samesign .* ((m1 + m2) / 2);
   else
     m = (m1 + m2) / 2;
   endif
+
+  m(infmask) = m1(infmask) + m2(infmask);
 endfunction
+
+
+## Tests for per-element Inf handling in even-length median
+%!test
+%! x = [-Inf, 2; 1, 3];
+%! assert (median (x, 1), [-Inf, 2.5]);
+
+%!test
+%! x = [-Inf, Inf; Inf, -Inf];
+%! assert (median (x, 1), [NaN, NaN]);
+
+%!test
+%! x = [1, Inf, 3; 5, 7, 9];
+%! assert (median (x, 1), [3, Inf, 6]);
+
+%!test
+%! x = int64 ([10, 20; 30, 40]);
+%! assert (median (x, 1), int64 ([20, 30]));
 
 
 %!assert (median (1), 1)

--- a/scripts/statistics/median.m
+++ b/scripts/statistics/median.m
@@ -564,6 +564,24 @@ function m = mid_two_vals (m1, m2, is_int)
 endfunction
 
 
+## Tests for per-element Inf handling in even-length median
+%!test
+%! x = [-Inf, 2; 1, 3];
+%! assert (median (x, 1), [-Inf, 2.5]);
+
+%!test
+%! x = [-Inf, Inf; Inf, -Inf];
+%! assert (median (x, 1), [NaN, NaN]);
+
+%!test
+%! x = [1, Inf, 3; 5, 7, 9];
+%! assert (median (x, 1), [3, Inf, 6]);
+
+%!test
+%! x = int64 ([10, 20; 30, 40]);
+%! assert (median (x, 1), int64 ([20, 30]));
+
+
 %!assert (median (1), 1)
 %!assert (median ([1, 2, 3]), 2)
 %!assert (median ([1, 2, 3]'), 2)


### PR DESCRIPTION
As pointed out in the [community](https://octave.discourse.group/t/in-octave-median-is-o-n-log-n-no-asymptotic-gain-over-sort-extra-hidden-work/7276) about the hidden cost of median(x) and possible fix.
### Summary

This change replaces the full sort used in `median()` for dense inputs with order-statistic selection via `nth_element`, reducing average complexity from **O(n log n)** to **O(n)**. Sparse inputs retain the original sort-based code path to preserve historical behavior and output sparsity.

---

### Algorithmic change

Previous implementation:
- `sort(x)` followed by indexing middle element(s)

New implementation:
- `nth_element(x, k)` for odd length
- `nth_element(x, [k, k+1])` for even length

This computes only the required order statistics without fully sorting.

---

### NaN handling

NaN semantics are preserved explicitly:

- `"omitnan"`: NaNs are filtered before selection.
- `"includenan"`: slices containing NaNs return NaN.

This matches the behavior previously provided implicitly by `sort()`

---
### Sparse behavior

Sparse inputs continue to use the original sort-based code path to preserve:
- sparsity of outputs,
- historical indexing behavior,
- and memory characteristics.

Dense inputs use the new `nth_element` path.

---
I went a step ahead and ran a benchmark to see if it's really doing the speed up as promised, here are the results below. I am also attaching the benchmarking script.

### Performance

Benchmarks on large dense inputs (Octave 9.x, Apple clang):

| Case | Size | Before (s) | After (s) | Speedup |
|------|------|------------|-----------|---------|
| Vector | 10,000 | 0.001555 | 0.000634 | 2.5× |
| Vector | 100,000 | 0.008014 | 0.001303 | 6.2× |
| Vector | 500,000 | 0.044739 | 0.005207 | 8.6× |
| Vector | 1,000,000 | 0.095003 | 0.012283 | 7.7× |
| Matrix (n×100) | 10,000 | 0.060745 | 0.015934 | 3.8× |
| Matrix (n×100) | 100,000 | 0.754142 | 0.126997 | 5.9× |
| Matrix (n×100) | 500,000 | 4.648894 | 0.590293 | 7.9× |
| Matrix (n×100) | 1,000,000 | 9.967157 | 1.471443 | 6.8× |
| omitnan (n×100) | 10,000 | 0.071202 | 0.015734 | 4.5× |
| omitnan (n×100) | 100,000 | 0.717203 | 0.117018 | 6.1× |
| omitnan (n×100) | 500,000 | 4.470758 | 0.560758 | 8.0× |
| omitnan (n×100) | 1,000,000 | 9.405867 | 1.238683 | 7.6× |

Speedup grows with input size, consistent with removal of the `log n` factor.

---

<img width="2045" height="1363" alt="bench_median_comparison" src="https://github.com/user-attachments/assets/01fb8bbf-49a4-4ea0-a64b-792854c46aa7" />

Benchmarking Script can be found [here](https://pastebin.com/7iB8wjY4)
CSV results from which plots were generated can be found [here](https://github.com/user-attachments/files/24808338/bench_results.csv)

---
## Notes
- No semantic or API changes.
- Only the internal selection algorithm is modified.
- All existing tests pass
- All existing BISTs pass unchanged.
- As [mentioned in community](https://octave.discourse.group/t/in-octave-median-is-o-n-log-n-no-asymptotic-gain-over-sort-extra-hidden-work/7276/6?u=beingamanforever), NaN values are taken care of properly
- I can move to improving the implementation of KDTree and improve it's build time if this gets merged as median was being a bottleneck as [raised in this issue](https://github.com/gnu-octave/statistics/issues/356)