### PR TITLE
Fix incorrect memory allocation check in getmemi

### DIFF
--- a/liboctave/util/oct-sort.cc
+++ b/liboctave/util/oct-sort.cc
@@ -563,7 +563,7 @@ template <typename T>
 void
 octave_sort<T>::MergeState::getmemi (octave_idx_type need)
 {
-  if (m_ia && need <= m_alloced)
+  if (m_a && m_ia && need <= m_alloced)
     return;
 
   need = roundupsize (need);


### PR DESCRIPTION
 This patch fixes a logic bug in the `getmemi` method of `octave_sort<T>::MergeState` (in `liboctave/util/oct-sort.cc`).

### Problem
The original code returned early if `m_ia` was non-null and `need <= m_alloced`, but did not check whether `m_a` was also allocated. This could lead to a situation where `m_ia` is null, `m_alloced` is large enough, and the function exits without allocating memory — resulting in undefined behavior.

### Fix
The condition is updated to:
```cpp
if (m_a && m_ia && need <= m_alloced)
  return;
