### PR TITLE
Fix: Reset index j in mismatch branch to prevent stale access

### DIFF
--- a/liboctave/array/Array-base.cc
+++ b/liboctave/array/Array-base.cc
@@ -1391,18 +1391,18 @@ Array<T, Alloc>::assign (const Array<octave::idx_vector>& ia,
             }
         }
       else
-        {
-          // dimension mismatch, unless LHS and RHS both empty
-          bool lhsempty, rhsempty;
-          lhsempty = rhsempty = false;
-          dim_vector lhs_dv = dim_vector::alloc (ial);
-          for (int i = 0; i < ial; i++)
-            {
-              octave_idx_type l = ia(i).length (rdv(i));
-              lhs_dv(i) = l;
-              lhsempty = lhsempty || (l == 0);
-              rhsempty = rhsempty || (rhdv(j++) == 0);
-            }
+       {
+         bool lhsempty, rhsempty;
+         lhsempty = rhsempty = false;
+         dim_vector lhs_dv = dim_vector::alloc (ial);
+         j = 0;  // FIX: Reset j before reusing it
+         for (int i = 0; i < ial; i++)
+           {
+             octave_idx_type l = ia(i).length (rdv(i));
+             lhs_dv(i) = l;
+             lhsempty = lhsempty || (l == 0);
+             rhsempty = rhsempty || (j < rhdvl && rhdv(j++) == 0);
+           }
           if (! lhsempty || ! rhsempty)
             {
               lhs_dv.chop_trailing_singletons ();

--- a/liboctave/array/Array-base.cc
+++ b/liboctave/array/Array-base.cc
@@ -1391,24 +1391,40 @@ Array<T, Alloc>::assign (const Array<octave::idx_vector>& ia,
             }
         }
       else
-       {
-         bool lhsempty, rhsempty;
-         lhsempty = rhsempty = false;
-         dim_vector lhs_dv = dim_vector::alloc (ial);
-         j = 0;  // FIX: Reset j before reusing it
-         for (int i = 0; i < ial; i++)
-           {
-             octave_idx_type l = ia(i).length (rdv(i));
-             lhs_dv(i) = l;
-             lhsempty = lhsempty || (l == 0);
-             rhsempty = rhsempty || (j < rhdvl && rhdv(j++) == 0);
+         { 
+            bool lhsempty = false;
+             bool rhsempty = false;
+           
+             dim_vector lhs_dv = dim_vector::alloc (ial);
+           
+             j = 0;  // Reset j before reusing it
+           
+             for (int i = 0; i < ial; i++)
+               {
+                 // Compute lhs dimension length
+                 octave_idx_type l = ia(i).length (rdv(i));
+                 lhs_dv(i) = l;
+           
+                 // Check if lhs dimension is empty
+                 lhsempty = lhsempty || (l == 0);
+           
+                 // Bounds check before accessing rhdv
+                 if (j < rhdvl)
+                   {
+                     bool rhs_is_empty = (rhdv[j] == 0);  // safe access
+                     j++;  // increment index after use
+                     rhsempty = rhsempty || rhs_is_empty;
+                   }
+               }
+           
+             // This part is fine as-is
+             if (! lhsempty || ! rhsempty)
+               {
+                 lhs_dv.chop_trailing_singletons ();
+                 octave::err_nonconformant ("=", lhs_dv, rhdv);
+              }
            }
-          if (! lhsempty || ! rhsempty)
-            {
-              lhs_dv.chop_trailing_singletons ();
-              octave::err_nonconformant ("=", lhs_dv, rhdv);
-            }
-        }
+
     }
 }
 


### PR DESCRIPTION
This patch addresses a bug in    liboctave/array/Array-base.cc     where the index variable j was reused without being reset in the mismatch branch.
Previously ,     j      could retain a stale value, leading to incorrect indexing and potential out‑of‑bounds access when evaluating rhdv(j++).
Changes introduced:
- Reset    j = 0     before reuse in the mismatch branch.
- Added a bounds check (j < rhdvl) to ensure safe access to rhdv.
- Simplified logic to improve readability and maintain defensive programming practices.



mpact:
- Prevents invalid memory access.
- Ensures correct dimension handling in mismatch cases.
- Improves code safety and clarity without altering existing functionality.
