### PR TITLE
Draft: Change editieren to bearbeiten in de_DE.ts

### DIFF
--- a/libgui/languages/de_DE.ts
+++ b/libgui/languages/de_DE.ts
@@ -45,7 +45,7 @@
     <message>
         <location filename="../qterminal/libqterminal/QTerminal.cc" line="+119"/>
         <source>Edit &quot;%1&quot;</source>
-        <translation>Bearbeiten &quot;%1&quot;</translation>
+        <translation>Bearbeite &quot;%1&quot;</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -1612,7 +1612,7 @@ wurde gelöscht oder umbenannt. Soll die Datei jetzt gespeichert werden?%2</tran
         <location line="+1"/>
         <source>Create file in
 </source>
-        <comment>String ends with 
+        <comment>String ends with
 !</comment>
         <translation>Neue Datei in
 </translation>
@@ -1644,7 +1644,7 @@ konnte nicht erstellt werden.</translation>
         <location line="+1"/>
         <source>Create folder in
 </source>
-        <comment>String ends with 
+        <comment>String ends with
 !</comment>
         <translation>Neues Verzeichnis in
 </translation>
@@ -2666,18 +2666,18 @@ oder Web-Verbindungen für Nachrichten müssen im Octave Einstellungsdialog, Rei
     <name>octave::octave_qscintilla</name>
     <message>
         <location filename="../src/m-editor/octave-qscintilla.cc" line="+302"/>
-        <source>Help on</source>
-        <translation>Hilfe zu</translation>
+        <source>Help on %1</source>
+        <translation>Hilfe zu %1</translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Documentation on</source>
-        <translation>Dokumentation zu</translation>
+        <source>Documentation on %1</source>
+        <translation>Dokumentation zu %1</translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>Edit</source>
-        <translation>Bearbeiten</translation>
+        <source>Edit %1</source>
+        <translation>Bearbeite %1</translation>
     </message>
     <message>
         <location line="+15"/>

--- a/libgui/languages/de_DE.ts
+++ b/libgui/languages/de_DE.ts
@@ -45,7 +45,7 @@
     <message>
         <location filename="../qterminal/libqterminal/QTerminal.cc" line="+119"/>
         <source>Edit &quot;%1&quot;</source>
-        <translation>Editiere &quot;%1&quot;</translation>
+        <translation>Bearbeiten &quot;%1&quot;</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -1265,7 +1265,7 @@ Speichern der geänderten Datei könnte zu Datenverlust führen!</translation>
     <message>
         <location line="+10"/>
         <source>&amp;Edit anyway</source>
-        <translation>Trotzdem &amp;editieren</translation>
+        <translation>Trotzdem b&amp;earbeiten</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -2251,7 +2251,7 @@ Klicken Sie auf &apos;Weiter&apos;, um eine Konfigurationsdatei anzulegen und Oc
         <source>%1 is a built-in, compiled, or inline
 function and can not be edited.</source>
         <translation>%1 ist eine interne, kompilierte oder inline
-definierte Funktion und kann nicht editiert werden.</translation>
+definierte Funktion und kann nicht bearbeitet werden.</translation>
     </message>
     <message>
         <location line="+41"/>

--- a/libgui/src/m-editor/octave-qscintilla.cc
+++ b/libgui/src/m-editor/octave-qscintilla.cc
@@ -299,12 +299,11 @@ octave_qscintilla::contextMenuEvent (QContextMenuEvent *e)
           m_word_at_cursor = wordAtPoint (local_pos);
           if (! m_word_at_cursor.isEmpty ())
             {
-              context_menu->addAction (tr ("Help on") + ' ' + m_word_at_cursor,
+              context_menu->addAction (tr ("Help on %1").arg(m_word_at_cursor),
                                        this, &octave_qscintilla::contextmenu_help);
-              context_menu->addAction (tr ("Documentation on")
-                                       + ' ' + m_word_at_cursor,
+              context_menu->addAction (tr ("Documentation on %1").arg(m_word_at_cursor),
                                        this, &octave_qscintilla::contextmenu_doc);
-              context_menu->addAction (tr ("Edit") + ' ' + m_word_at_cursor,
+              context_menu->addAction (tr ("Edit %1").arg(m_word_at_cursor),
                                        this, &octave_qscintilla::contextmenu_edit);
             }
         }


### PR DESCRIPTION
The string to edit file with context menue is different in editor and console. This patch unifies these words. 
Place of string:
<img width="318" height="307" alt="image" src="https://github.com/user-attachments/assets/f7a3d20d-b8d9-41b2-b328-33b77a1c6207" />
Like in text editor:
<img width="591" height="619" alt="image" src="https://github.com/user-attachments/assets/f41f60e9-2f01-47a7-81d3-de37c0c77722" />
